### PR TITLE
changes in the TimerSettings, TimerControls, and store

### DIFF
--- a/src/components/SettingsDialog/NavigationMenu/NavigationMenu.tsx
+++ b/src/components/SettingsDialog/NavigationMenu/NavigationMenu.tsx
@@ -16,7 +16,7 @@ const NavigationMenu = () => {
   const defaults = {
     timers: {
       inputs: { pomodoro: 25, shortBreak: 5, longBreak: 15 },
-      pomodoroSequenceOn: false,
+      isPomodoroSequenceOn: false,
     },
   };
 
@@ -43,7 +43,7 @@ const NavigationMenu = () => {
     setTimersSettings(defaults.timers);
     timersSettingsRef.current!.resetTimersSettings(defaults.timers.inputs);
     timersSettingsRef.current!.resetPomodoroSequence(
-      defaults.timers.pomodoroSequenceOn
+      defaults.timers.isPomodoroSequenceOn
     );
   };
 

--- a/src/components/SettingsDialog/TimersSettings/TimersSettings.tsx
+++ b/src/components/SettingsDialog/TimersSettings/TimersSettings.tsx
@@ -23,6 +23,13 @@ const TimersSettings = forwardRef((_props, ref) => {
   const { settings, setIsSettingsDialogOpen, setTimersSettings } =
     useTimerStore((state) => state);
 
+  const { inputs, isPomodoroSequenceOn } = settings.timers;
+  const {
+    pomodoro: pomodoroLength,
+    shortBreak: shortBreakLength,
+    longBreak: LongBreakLength,
+  } = inputs;
+
   const { timers } = settings;
 
   // Initialize state with default values from config
@@ -33,7 +40,7 @@ const TimersSettings = forwardRef((_props, ref) => {
 
   const [formState, setFormState] = useState(initialFormState);
   const [pomodoroSequenceOn, setPomodoroSequenceOn] = useState(
-    timers.pomodoroSequenceOn
+    timers.isPomodoroSequenceOn
   );
 
   useImperativeHandle(
@@ -69,8 +76,22 @@ const TimersSettings = forwardRef((_props, ref) => {
 
   const onFormSubmitHandler = (e: FormEvent) => {
     e.preventDefault();
-    const data = { inputs: formState, pomodoroSequenceOn };
-    setTimersSettings(data);
+    const data = {
+      inputs: formState,
+      isPomodoroSequenceOn: pomodoroSequenceOn,
+    };
+
+    const settingsHaveChanged =
+      formState.pomodoro !== pomodoroLength ||
+      formState.shortBreak !== shortBreakLength ||
+      formState.longBreak !== LongBreakLength ||
+      pomodoroSequenceOn !== isPomodoroSequenceOn;
+
+    if (settingsHaveChanged) {
+      setTimersSettings(data);
+      return setIsSettingsDialogOpen();
+    }
+
     setIsSettingsDialogOpen();
   };
 

--- a/src/components/Timer/TimerControls/TimerControls.tsx
+++ b/src/components/Timer/TimerControls/TimerControls.tsx
@@ -24,6 +24,7 @@ const TimerControls = () => {
     const intervalRef = setInterval(setTimerData, 1000);
     setCurrentIntervalID(intervalRef);
   };
+
   return (
     <div className="flex space justify-around pt-[20px]">
       <Button

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -10,7 +10,7 @@ export type SessionData = {
 
 export interface TimersSettings {
   inputs: SessionData;
-  pomodoroSequenceOn: boolean;
+  isPomodoroSequenceOn: boolean;
 }
 
 export type DialogNavItem = "timers";


### PR DESCRIPTION
In TimerSettings, new values are stored only if the form values have changed—no timer reset if the values remain the same. The timer stops when new settings are saved. Added the possibility for the timer to run a single session (no Pomodoro sequence). Fixed a bug where an incorrect session was selected—short break after 4 working sessions instead of a long break.